### PR TITLE
feat: Set background2.jpg as body background

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,9 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-    background-color: #1a1a1a;
+    background-image: url('background2.jpg');
+    background-size: cover;
+    background-position: center;
     color: #ffffff;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
This commit updates the inline CSS within `index.html` to set `background2.jpg` as the background image for the `body` element. The `background-size` and `background-position` properties have also been added to ensure the image covers the entire page and is centered.